### PR TITLE
Úprava modelu profilu uživatel

### DIFF
--- a/model/profile.py
+++ b/model/profile.py
@@ -29,4 +29,4 @@ class Profile(Base):
     school_zip = Column(String(20), nullable=False)
     school_country = Column(countries, nullable=False)
     school_finish = Column(Integer, nullable=False)
-    tshirt_size = Column(Enum('XS', 'S', 'M', 'L', 'XL'), nullable=False)
+    tshirt_size = Column(Enum('XS', 'S', 'M', 'L', 'XL', 'NA'), nullable=False)

--- a/model/profile.py
+++ b/model/profile.py
@@ -30,3 +30,5 @@ class Profile(Base):
     school_country = Column(countries, nullable=False)
     school_finish = Column(Integer, nullable=False)
     tshirt_size = Column(Enum('XS', 'S', 'M', 'L', 'XL', 'NA'), nullable=False)
+    gdpr_accepted_version = Column(Integer, nullable=False)
+    gdpr_accepted_timestamp = Column(TIMESTAMP)


### PR DESCRIPTION
V rámci přípravy na nový ročník by bylo nanejvýš vhodné mít následující úpravy:
- Do Enumu velikosti trička přidat možnost, kdy uživatel nechce sdělit.
- Přidat možnost do DB uložit, zda, kdy a kterou verzi GDPR souhlasu řešitel potvrdil.
Kdy je timestamp, verze je integer.
GDPR souhlas by měl být editovatelný ze dvou endpointů - registrace a nastavení.

Navržené lokace v DB už jsou v této větvy, pokud bys to chtěl dát někam jinam, asi ok.
U úpravy enumu prosím pozor, ať celý ten sloupec neztratíme při ALTER TABLE.
Hodnota "NA" je navržená místo NULL proto, že práce s undefined je v Ember 1.13 taková _zábavná_.

PR neobsahuje kód pro upravené endpointy, i tak jsem ho ale vytvořil, abychom měli jednotné místo kde o úpravě vlastností uživatelů diskutovat.