### PR TITLE
feat(year): treat point pad as a maximal number of points

### DIFF
--- a/endpoint/admin/userExport.py
+++ b/endpoint/admin/userExport.py
@@ -123,12 +123,12 @@ class UserExport(object):
                                        year_end).\
                 all()
 
-            sum_points = util.task.sum_points(
-                req.context['year'],
-                bonus=False) + year_obj.point_pad
-            sum_points_bonus = util.task.sum_points(
-                req.context['year'],
-                bonus=True) + year_obj.point_pad
+            sum_points_real = util.task.sum_points(req.context['year'], bonus=False)
+            sum_points_bonus_real = util.task.sum_points(req.context['year'], bonus=True)
+            sum_points = max(
+                sum_points_real,
+                year_obj.point_pad
+            )
 
             table_header = \
                 "Pořadí;" +\
@@ -152,8 +152,8 @@ class UserExport(object):
                 "Velikost trička\n"
 
             inMemoryOutputFile.write(
-                "Celkem bodů: " + str(sum_points) +
-                ", včetně bonusových úloh: " + str(sum_points_bonus) +
+                "Celkem bodů: " + str(sum_points_real) +
+                ", včetně bonusových úloh: " + str(sum_points_bonus_real) +
                 ", bodová vycpávka: " + str(year_obj.point_pad) + '\n'
             )
 

--- a/endpoint/user.py
+++ b/endpoint/user.py
@@ -232,8 +232,10 @@ class Users(object):
                 filter(model.Wave.year == year.id).\
                 group_by(model.User, model.Task).all()
 
-            max_points = util.task.sum_points(req.context['year'],
-                                              bonus=False) + year.point_pad
+            max_points = max(
+                util.task.sum_points(req.context['year'], bonus=False),
+                year.point_pad
+            )
 
             # Uzivatele s nedefinovanymi tasks_cnt v tomto rocniku
             # neodevzdali zadnou ulohu

--- a/util/profile.py
+++ b/util/profile.py
@@ -97,8 +97,10 @@ def _full_profile_to_json(user, profile, notify, task_scores, year_obj, sensitiv
     :return:
     """
     points, cheat = util.user.sum_points(user.id, year_obj.id)
-    summary = util.task.sum_points(
-        year_obj.id, bonus=False) + year_obj.point_pad
+    summary = max(util.task.sum_points(
+        year_obj.id, bonus=False),
+        year_obj.point_pad
+    )
     successful = format(floor((float(points) / summary) *
                               1000) / 10, '.1f') if summary != 0 else 0
 

--- a/util/user.py
+++ b/util/user.py
@@ -167,8 +167,10 @@ def successful_participants(year_obj):
         filter(model.User.role == 'participant').\
         group_by(model.User).all()
 
-    max_points = util.task.sum_points(year_obj.id, bonus=False) + \
+    max_points = max(
+        util.task.sum_points(year_obj.id, bonus=False),
         year_obj.point_pad
+    )
 
     return [
         (user, points)
@@ -228,8 +230,10 @@ def to_json(user, year_obj, total_score=None, tasks_cnt=None, profile=None,
         if profile is None:
             profile = session.query(model.Profile).get(user.id)
         if max_points is None:
-            max_points = util.task.sum_points(year_obj.id, bonus=False)\
-                + year_obj.point_pad
+            max_points = max(
+                util.task.sum_points(year_obj.id, bonus=False),
+                year_obj.point_pad
+            )
 
         data['addr_country'] = profile.addr_country
         data['school_name'] = profile.school_name


### PR DESCRIPTION
Po aplikaci tohoto patche se z bodové vycpávky místo přidaných bodů stane maximální očekávaný počet bodů (tj. maximum bodů v ročníku bude odteď `max(počet_bodů_z_úloh, bodová_vycpávka)`. Díky tomu bude po většinu roku stabilní procento bodů a po vypuštění 4. vlny se manuálně sníží vycpávka na 0.

Resolves https://github.com/fi-ksi/web-backend/issues/167