### PR TITLE
Automatická úprava bodové vycpávky

### DIFF
--- a/endpoint/admin/taskDeploy.py
+++ b/endpoint/admin/taskDeploy.py
@@ -27,6 +27,7 @@ class TaskDeploy(object):
 
         try:
             user = req.context['user']
+            year = req.context['year']
 
             # Kontrola opravneni
             if (not user.is_logged_in()) or (not user.is_org()):
@@ -77,7 +78,7 @@ class TaskDeploy(object):
                 deployLock.acquire(60)  # Timeout zamku je 1 minuta
                 deployThread = threading.Thread(
                     target=util.admin.taskDeploy.deploy,
-                    args=(task.id, deployLock, scoped_session(_session)),
+                    args=(task.id, deployLock, year, scoped_session(_session)),
                     kwargs={}
                 )
                 deployThread.start()

--- a/endpoint/admin/taskDeploy.py
+++ b/endpoint/admin/taskDeploy.py
@@ -78,7 +78,7 @@ class TaskDeploy(object):
                 deployLock.acquire(60)  # Timeout zamku je 1 minuta
                 deployThread = threading.Thread(
                     target=util.admin.taskDeploy.deploy,
-                    args=(task.id, deployLock, year, scoped_session(_session)),
+                    args=(task.id, deployLock, year.id, scoped_session(_session)),
                     kwargs={}
                 )
                 deployThread.start()

--- a/endpoint/admin/taskDeploy.py
+++ b/endpoint/admin/taskDeploy.py
@@ -27,7 +27,7 @@ class TaskDeploy(object):
 
         try:
             user = req.context['user']
-            year = req.context['year']
+            year_id: int = req.context['year']
 
             # Kontrola opravneni
             if (not user.is_logged_in()) or (not user.is_org()):
@@ -78,7 +78,7 @@ class TaskDeploy(object):
                 deployLock.acquire(60)  # Timeout zamku je 1 minuta
                 deployThread = threading.Thread(
                     target=util.admin.taskDeploy.deploy,
-                    args=(task.id, year.id, deployLock, scoped_session(_session)),
+                    args=(task.id, year_id, deployLock, scoped_session(_session)),
                     kwargs={}
                 )
                 deployThread.start()

--- a/endpoint/admin/taskDeploy.py
+++ b/endpoint/admin/taskDeploy.py
@@ -78,7 +78,7 @@ class TaskDeploy(object):
                 deployLock.acquire(60)  # Timeout zamku je 1 minuta
                 deployThread = threading.Thread(
                     target=util.admin.taskDeploy.deploy,
-                    args=(task.id, deployLock, year.id, scoped_session(_session)),
+                    args=(task.id, year.id, deployLock, scoped_session(_session)),
                     kwargs={}
                 )
                 deployThread.start()

--- a/util/admin/taskDeploy.py
+++ b/util/admin/taskDeploy.py
@@ -94,6 +94,7 @@ def deploy(task_id: int, year_id: int, deployLock: LockFile, scoped: Callable) -
         # Save max points before for modifying the point pad
         max_points_before: float = max_points(task.id)
         log(f"Current task max points: {max_points_before}")
+        log(f"Current year point pad: {year.point_pad}")
 
         # Parse task
         log("Parsing " + util.git.GIT_SEMINAR_PATH + task.git_path)

--- a/util/admin/taskDeploy.py
+++ b/util/admin/taskDeploy.py
@@ -105,12 +105,12 @@ def deploy(task_id: int, year_id: int, deployLock: LockFile, scoped: Callable) -
         max_points_diff = max_points_before - max_points_now
         log(f"New task max points: {max_points_now} (before {max_points_before}, diff {max_points_diff})")
 
-        if max_points_diff == 0:
+        if max_points_diff == 0.0:
             log("Point diff is zero, no change is necessary")
-        elif year.point_pad == 0:
+        elif year.point_pad == 0.0:
             log("The year's point pad is already zero, not modifying it")
         else:
-            new_point_pad = min(0.0, year.point_pad + max_points_diff)
+            new_point_pad = max(0.0, year.point_pad + max_points_diff)
             log(f"Setting the year's point pad to {new_point_pad}")
             year.point_pad = new_point_pad
 


### PR DESCRIPTION
Při každém deployi úlohy automaticky upraví bodovou vycpávku na základě diffu bodů úlohy - zabrání to tak velkým skokům v procentech řešitelů po zveřejnění vlny.

- Např. úloha měla 5 bodů, nově má 15 -> bodová vycpávka se sníží o 10 bodů.
- Bodová vycpávka se sníží maximálně na 0 bodů.
- Bodová vycpávka se nijak nemění (ani nahoru ani dolů), pokud už před deployem úlohy byla 0.

:warning: **Squash before merge**