### PR TITLE
Nastavování prerekvizit pomocí jména adresáře

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ data/
 config.py
 ksi-py3-venv
 .run/
+*/.vscode

--- a/model/task.py
+++ b/model/task.py
@@ -22,6 +22,9 @@ class Task(Base):
     author = Column(Integer, ForeignKey(User.id), nullable=True)
     co_author = Column(Integer, ForeignKey(User.id), nullable=True)
     wave = Column(Integer, ForeignKey(Wave.id), nullable=False)
+
+    wave_ = relationship('Wave')
+
     prerequisite = Column(Integer, ForeignKey('prerequisities.id',
                                               ondelete='SET NULL'),
                           nullable=True)

--- a/utils/use-named-requirements.py
+++ b/utils/use-named-requirements.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+"""
+Replaces all ID-based prerequisities with their name-based alternatives by resolving their IDs againts the backend
+
+Requires following environment variables:
+- YEAR - the year/directory name inside seminar repository
+- BACKEND - backend URL including https
+- TOKEN - your login token (can be extracted from frontend)
+
+The first argument may be path to the task.json file or to a directory in which the task.json is supposed to be recursivelly searched
+"""
+
+from urllib import request
+from pathlib import Path
+from typing import Set, NamedTuple, Dict
+from os import environ
+from sys import argv
+import json
+import re
+
+from util_login import KSILogin
+
+
+def fetch_task_path(task_id: int, backend_url: str, token: str) -> str:
+    """
+    Fetches git path for given task
+    :param backend_url: url of the backend, including https
+    :param token: login token
+    :param task_id: ID of the task to fetch
+    :return: git path of given task
+    """
+    with request.urlopen(request.Request(f"{backend_url}/admin/atasks/{task_id}", headers={'Authorization': token})) as res:
+        result = json.loads(res.read().decode('utf8'))
+    return result["atask"]["git_path"]
+
+
+def replace_requiements(file_task_meta: Path, backend_url: str, token: str) -> None:
+    print(f"[*] processing {file_task_meta.absolute()}")
+
+    with file_task_meta.open('r') as f:
+        content = json.load(f)
+
+    requirements = content["prerequisities"]
+    print(f"  [-] {requirements=}")
+    if requirements is None:
+        return
+    # force string for int-based requiements
+    requirements = str(requirements)
+
+    def _replace(match: re.Match):
+        prefix = match.group(1)
+        suffix = match.group(3)
+        task_id = int(match.group(2))
+        print(f"    [.] processing {task_id} ... ", end="", flush=True)
+        task_path = fetch_task_path(task_id, backend_url, token).rsplit('/', 1)[-1]
+        print(task_path)
+        return f"{prefix}{task_path}{suffix}"
+
+    requirements = re.sub(r"(^|\s)(\d+)($|\s)", _replace, requirements)
+    print(f"  [-] {requirements=}")
+    content["prerequisities"] = requirements
+
+    with file_task_meta.open('w') as f:
+        json.dump(content, f, indent=4)
+
+
+def main() -> int:
+    backend_url = environ['BACKEND']
+    if 'TOKEN' not in environ:
+        login = KSILogin(backend_url)
+        if not login.login(environ['USER'], environ.get('PASSWORD')):
+            print('ERROR: Login failed')
+            return 1
+        environ['TOKEN'] = login.token
+
+    backend = (backend_url, environ['TOKEN'])
+
+    source = Path(argv[1])
+    if source.is_file():
+        replace_requiements(source, *backend)
+    else:
+        for task_meta in source.rglob("task.json"):
+            replace_requiements(task_meta, *backend)
+
+
+if __name__ == '__main__':
+    exit(main())


### PR DESCRIPTION
**Současný stav**

V tuto chvíli vypadá tradiční soubor s metainformacemi o úloze jako:
```json
{
    "author": 21,
    "date_deadline": "2050-01-01",
    "prerequisities": "10 && 15",
    "icon_ref": 10,
    "version": "1.0"
}
```

Kdy backend při deployi nastaví úlohy s ID 10 a 15 jakožto prerekvizity.

**Proč toto není ideální**

U vln, které se často přesouvají do nového ročníku (např. 0. vlna) se musí pokaždé měnit manuálně prerekvizity všech úloh. Tato práce je manuální, nudná a náchylná k lidské chybě.

**Co navrhuji**

Jako doplněk k odkazu pomocí ID bychom mohli do prerekvizit psát i jména adresářů úloh, která bývají v rámci ročníku unikátní:

```json
{
    "author": 21,
    "date_deadline": "2050-01-01",
    "prerequisities": "uloha_16_outdoor_uloha && uloha_17_multiple_texts",
    "icon_ref": 10,
    "version": "1.0"
}
```

Backend při deployi poté vyhledá úlohy, které mají git path končící daným adresářem a zároveň jsou v současném ročníku. Díky tomu se při přesouvání vlny do nového ročníku nemusí pokaždé manuálně měnit ID prerekvizit, protože jméno adresáře zůstane stejné, což ušetří spoustu mechanické práce a zmenší prostor pro lidské chyby.

**Bonus**

Poměrně často se stává, že `prerequisities` má být string a napíšeme jedinou prerekvizitu jako číslo, což při deployi způsobí poměrně kryptickou hlášku. Nově je i zadávání jediné prerekvizity jako čísla s ID validní syntax:

```json
{
    "author": 21,
    "date_deadline": "2050-01-01",
    "prerequisities": 11,
    "icon_ref": 10,
    "version": "1.0"
}
```