### PR TITLE
fix(registration): add missing error message for duplicate email

### DIFF
--- a/endpoint/registration.py
+++ b/endpoint/registration.py
@@ -21,7 +21,7 @@ class Registration(object):
                 first()
 
             if existing_user is not None:
-                req.context['result'] = {'error': "duplicate_user"}
+                req.context['result'] = {'error': "Na tento e-mail je již někdo zaregistrovaný."}
                 return
         except SQLAlchemyError:
             session.rollback()


### PR DESCRIPTION
# What does this PR do?

This PR fixes the missing error message when a user attempts to register with an email address that's already in use. Now, users will see a clear error message indicating that the email is already registered.

# How did you verify your code works?

Tested it manually by trying to register with an existing email and confirmed that the error message appears as expected.