### PR TITLE
Add submit_ratelimit parameter to module.json (#188)

### DIFF
--- a/endpoint/module.py
+++ b/endpoint/module.py
@@ -277,11 +277,13 @@ class ModuleSubmit(object):
                            datetime.timedelta(days=1)).\
                     count()
 
-                if subm_in_last_day >= util.config.unsuccessful_tries_per_day():
+                if subm_in_last_day >= module.submit_ratelimit:
+                    print(subm_in_last_day)
+                    print(module.submit_ratelimit)
                     req.context['result'] = {
                         'result': 'error',
                         'error': ('Překročen limit odevzdání '
-                                  '(20 odevzdání / 24 hodin).')
+                                  f'({module.submit_ratelimit} odevzdání / 24 hodin).')
                     }
                     return
 

--- a/model/module.py
+++ b/model/module.py
@@ -38,3 +38,4 @@ class Module(Base):
     custom = Column(Boolean, nullable=False, default=False)
     action = Column(Text)
     data = Column(Text)
+    submit_ratelimit = Column(Integer, nullable=False)

--- a/util/admin/taskDeploy.py
+++ b/util/admin/taskDeploy.py
@@ -111,7 +111,7 @@ def deploy(task_id: int, year_id: int, deployLock: LockFile, scoped: Callable) -
         max_points_before: float = max_points(task.id)
         log(f"Current task max points: {max_points_before}", task=task_id)
         log(f"Current year point pad: {year.point_pad}", task=task_id)
-
+        
         # Parse task
         log("Parsing " + util.git.GIT_SEMINAR_PATH + task.git_path)
         process_task(task, util.git.GIT_SEMINAR_PATH + task.git_path)
@@ -493,7 +493,8 @@ def process_modules(task, git_path, replacement_metadata: Optional[ReplacementMe
                 task=task.id,
                 type="general",
                 name="",
-                order=i
+                order=i,
+                submit_ratelimit=20
             )
             session.add(module)
             session.commit()
@@ -578,6 +579,7 @@ def process_module_json(module: model.Module, filename: str) -> ModuleSpecs:
     module.autocorrect = data['autocorrect']
     module.bonus = data['bonus'] if 'bonus' in data else False
     module.action = data['action'] if 'action' in data else ""
+    module.submit_ratelimit = data["submit_ratelimit"] if "submit_ratelimit" in data else 20
     if isinstance(module.action, dict):
         module.action = json.dumps(module.action, indent=2, ensure_ascii=False)
 


### PR DESCRIPTION
Description:
This PR addresses issue #188 by adding a new submit_ratelimit parameter to module.json. This parameter allows setting a submission limit per module.
If the parameter is not specified, the default behavior remains unchanged (20 submits/24h).